### PR TITLE
Adjusted IDE/JavaScript.md with location for tern

### DIFF
--- a/en_US/IDE/JavaScript.md
+++ b/en_US/IDE/JavaScript.md
@@ -47,6 +47,7 @@ You have to install tern since [tern_for_vim](https://github.com/ternjs/tern_for
 (If I was wrong, please tell me. Because I am not a expert of nodejs)
 
 Just Simply run:
+> cd ~/.cache/vimfiles/repos/github.com/ternjs/tern_for_vim
 > npm install tern
 
 **Or**


### PR DESCRIPTION
`npm install tern` needs to be run in `tern_for_vim`s plugin directory, ref documentation at https://github.com/ternjs/tern_for_vim